### PR TITLE
small typos

### DIFF
--- a/PIE_context.py
+++ b/PIE_context.py
@@ -123,7 +123,7 @@ class SUBPIE_MT_separate(Menu):
         # NORTH-EAST
         pie.operator("mesh.separate", text='By Material').type = 'MATERIAL'
         # SOUTH-WEST
-        pie.operator("mesh.edge_split", text='Split By Vertice').type = 'VERT'
+        pie.operator("mesh.edge_split", text='Split By Vertex').type = 'VERT'
         # SOUTH-EAST
         pie.operator("mesh.separate", text='Selection').type = 'SELECTED'
 
@@ -177,7 +177,7 @@ class SUBPIE_MT_extrudeFaces(Menu):
         # NORTH-EAST
         pie.operator("mesh.wireframe")
         # SOUTH-WEST
-        pie.operator("wm.tool_set_by_id", text="Extrud To Cursor Tool").name = "builtin.extrude_to_cursor"
+        pie.operator("wm.tool_set_by_id", text="Extrude To Cursor Tool").name = "builtin.extrude_to_cursor"
         # SOUTH-EAST
         pie.operator("view3d.edit_mesh_extrude_move_normal", text="Extrude")
 
@@ -224,7 +224,7 @@ class SUBPIE_MT_applyTransform(Menu):
         op.scale = False
 
         # NORTH
-        op = pie.operator("object.transform_apply", text="All Trasnforms")
+        op = pie.operator("object.transform_apply", text="All Transforms")
         op.location = True
         op.rotation = True
         op.scale = True


### PR DESCRIPTION
This fixes small typos visible to the user.

<img width="300" alt="Screen Shot 2024-04-09 at 11 52 07 AM" src="https://github.com/bastianlstrube/ContextPie/assets/54873330/8c10c9ba-2195-42b8-b916-aee31463e655">

<img width="300" alt="Screen Shot 2024-04-09 at 11 53 24 AM" src="https://github.com/bastianlstrube/ContextPie/assets/54873330/33e20bbb-689b-40b6-be50-de9042c7df63">


<img width="300" alt="Screen Shot 2024-04-09 at 11 51 50 AM" src="https://github.com/bastianlstrube/ContextPie/assets/54873330/395a5d01-0f78-4f13-ba99-c3971df6cc50">
